### PR TITLE
Fix: Generate sitemap

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -26,6 +26,8 @@ footer-links:
 
 # Build settings
 theme: minima
+plugins:
+    - jekyll-sitemap
 
 # Set the Sass partials directory, as we're using @imports
 sass:


### PR DESCRIPTION
Fixes a minor issue introduced with the latest pull request #1.
The plugin "[jekyll-sitemap](https://github.com/jekyll/jekyll-sitemap)" has to be specified explicitly.

Quote from the docs:
> When building a site that uses the GitHub Pages gem, follow the instructions above and ensure that jekyll-sitemap is listed in the plugins array in _config.yml.